### PR TITLE
use Time.System instead of deprecated new SystemTime()

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch_2_4/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch_2_4/ElasticsearchWriter.java
@@ -25,7 +25,7 @@ import io.confluent.connect.elasticsearch_2_4.jest.JestElasticsearchClient;
 import io.confluent.connect.elasticsearch_2_4.parent.mapping.ParentMapper;
 import io.confluent.connect.elasticsearch_2_4.route.mapping.RouteMapper;
 import io.confluent.connect.elasticsearch_2_4.type.mapping.TypeMapper;
-import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -406,7 +406,7 @@ public class ElasticsearchWriter {
   private BulkProcessor<IndexableRecord, ?> getBulkProcessor(String clusterKey) {
     if (!bulkProcessors.containsKey(clusterKey)) {
       BulkProcessor<IndexableRecord, ?> bp = new BulkProcessor<>(
-          new SystemTime(),
+          Time.SYSTEM,
           new BulkIndexingClient(getClient(clusterKey)),
           maxBufferedRecords,
           maxInFlightRequests,

--- a/src/main/java/io/confluent/connect/elasticsearch_2_4/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch_2_4/jest/JestElasticsearchClient.java
@@ -69,7 +69,6 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.common.security.ssl.SslFactory;
-import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -113,7 +112,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
 
   private int maxRetries;
   private long retryBackoffMs;
-  private final Time time = new SystemTime();
+  private final Time time = Time.SYSTEM;
   private int retryOnConflict;
 
   // visible for testing


### PR DESCRIPTION
## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
